### PR TITLE
Changed the place required to download the grsecurity patch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ linux-${VERSION}.tar.xz:
 	curl -OL https://cdn.kernel.org/pub/linux/kernel/v4.x/$@
 
 grsecurity-${GRSEC_RELEASE}.patch: grsecurity-${GRSEC_RELEASE}.patch.sig
-	curl -OL http://grsecurity.net/test/$@
+	curl -OL http://mirrors.muarf.org/grsecurity/test/$@
 	gpg --verify $@.sig $@ || rm -f $@
 
 grsecurity-${GRSEC_RELEASE}.patch.sig:
-	curl -OL http://grsecurity.net/test/$@
+	curl -OL http://mirrors.muarf.org/grsecurity/test/$@
 
 clean-package:
 	rm -rf ${PKGSTAGING} ${PKGSTAGING}.deb

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ linux-${VERSION}.tar.xz:
 	curl -OL https://cdn.kernel.org/pub/linux/kernel/v4.x/$@
 
 grsecurity-${GRSEC_RELEASE}.patch: grsecurity-${GRSEC_RELEASE}.patch.sig
-	curl -OL http://mirrors.muarf.org/grsecurity/test/$@
+	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.5/$@
 	gpg --verify $@.sig $@ || rm -f $@
 
 grsecurity-${GRSEC_RELEASE}.patch.sig:
-	curl -OL http://mirrors.muarf.org/grsecurity/test/$@
+	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.5/$@
 
 clean-package:
 	rm -rf ${PKGSTAGING} ${PKGSTAGING}.deb

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean-package clean clean-all build help
 
-VERSION=4.5.7
+VERSION=4.7.5
 GRSEC_RELEASE=3.1-${VERSION}-201606202152
 PATCHES=
 N_CORES=`cat /proc/cpuinfo | grep 'core id' | sort | uniq | wc -l`
@@ -67,11 +67,11 @@ linux-${VERSION}.tar.xz:
 	curl -OL https://cdn.kernel.org/pub/linux/kernel/v4.x/$@
 
 grsecurity-${GRSEC_RELEASE}.patch: grsecurity-${GRSEC_RELEASE}.patch.sig
-	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.5/$@
+	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.7/$@
 	gpg --verify $@.sig $@ || rm -f $@
 
 grsecurity-${GRSEC_RELEASE}.patch.sig:
-	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.5/$@
+	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.7/$@
 
 clean-package:
 	rm -rf ${PKGSTAGING} ${PKGSTAGING}.deb

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean-package clean clean-all build help
 
 VERSION=4.5.7
-GRSEC_RELEASE=3.1-${VERSION}-201606202152
+GRSEC_RELEASE=3.1-${VERSION}-201606302132
 PATCHES=
 N_CORES=`cat /proc/cpuinfo | grep 'core id' | sort | uniq | wc -l`
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean-package clean clean-all build help
 
-VERSION=4.7.5
+VERSION=4.5.7
 GRSEC_RELEASE=3.1-${VERSION}-201606202152
 PATCHES=
 N_CORES=`cat /proc/cpuinfo | grep 'core id' | sort | uniq | wc -l`
@@ -67,11 +67,11 @@ linux-${VERSION}.tar.xz:
 	curl -OL https://cdn.kernel.org/pub/linux/kernel/v4.x/$@
 
 grsecurity-${GRSEC_RELEASE}.patch: grsecurity-${GRSEC_RELEASE}.patch.sig
-	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.7/$@
+	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.5/$@
 	gpg --verify $@.sig $@ || rm -f $@
 
 grsecurity-${GRSEC_RELEASE}.patch.sig:
-	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.7/$@
+	curl -OL http://deb.digdeo.fr/grsecurity-archives/kernel-4.5/$@
 
 clean-package:
 	rm -rf ${PKGSTAGING} ${PKGSTAGING}.deb

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Build Instructions
 
 ```
 # Import Brad Spengler's GPG key
-gpg --recv 2525FE49
+
+wget https://grsecurity.net/spender-gpg-key.asc
+gpg --import spender-gpg-key.asc
 
 # Import the Linux stable GPG key
 gpg --recv 6092693E


### PR DESCRIPTION
Changed the place required to download the grsecurity patch. The previous one is obsolete.
