### PR TITLE
README.md: replace short Key IDs to complete fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Build Instructions
 
 ```
 # Import Brad Spengler's GPG key
-gpg --recv 2525FE49
+gpg --recv DE9452CE46F42094907F108B44D1C0F82525FE49
 
 # Import the Linux stable GPG key
-gpg --recv 6092693E
+gpg --recv 647F28654894E3BD457199BE38DBBDC86092693E
 
 # Build linux-grsecurity_<version>.deb
 fakeroot make


### PR DESCRIPTION
https://soylentnews.org/article.pl?sid=16/08/14/2256205&from=rss

Nobody should use short Key IDs, or any key IDs anymore,
Today, a short ID collision attack takes 5 seconds to complete,
and both spender and ghk are victims already.

Merely switching from 32 to 64 bits is not a proper fix.

> In short, that cutting a fingerprint in order to get a (32- or 64-bit)
> short key ID is the worst of all worlds, and we should rather target
> either always showing full fingerprints, or not showing it at all
> (and leaving all the crypto-checking bits to be done by the software,
> as comparing 160-bit strings is not natural for us humans).
> Gunnar Wolf

See fake keys:
https://pgp.mit.edu/pks/lookup?search=0x2525FE49&op=index
https://pgp.mit.edu/pks/lookup?search=0x6092693E&op=index

Signed-off-by: Tom Li biergaizi@member.fsf.org
